### PR TITLE
Use parallel iterator for files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Using globs:
 
 ```
 tc *.md
+
+# number of threads for parallel glob expansion
+RAYON_NUM_THREADS=8 tc *.md
 ```
 
 Arguments:


### PR DESCRIPTION
https://docs.rs/rayon/latest/rayon/iter/trait.IntoParallelIterator.html


Before
```
time tc 'huggingface/transformers/**/*.py' | wc -l
3135

tc 'huggingface/transformers/**/*.py'  13.94s user 1.03s system 94% cpu 15.840 total
wc -l  0.00s user 0.01s system 0% cpu 15.839 total
```

After
```
time RAYON_NUM_THREADS=8 ./target/release/tc 'huggingface/transformers/**/*.py' | wc -l
Glob expansion for 'huggingface/transformers/**/*.py' took 75.277916ms
Total glob expansion took 3.251318709s
3135

RAYON_NUM_THREADS=8 ./target/release/tc   23.37s user 1.14s system 725% cpu 3.380 total
```